### PR TITLE
Filter site packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 
-# Created by https://www.gitignore.io/api/python,intellij
-# Edit at https://www.gitignore.io/?templates=python,intellij
+# Created by https://www.gitignore.io/api/python,intellij+all
+# Edit at https://www.gitignore.io/?templates=python,intellij+all
 
-### Intellij ###
+### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
@@ -72,23 +72,21 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
-### Intellij Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
 
 # Sonarlint plugin
-.idea/**/sonarlint/
-
-# SonarQube Plugin
-.idea/**/sonarIssues.xml
-
-# Markdown Navigator plugin
-.idea/**/markdown-navigator.xml
-.idea/**/markdown-navigator/
+.idea/sonarlint
 
 ### Python ###
 # Byte-compiled / optimized / DLL files
@@ -195,4 +193,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# End of https://www.gitignore.io/api/python,intellij
+# End of https://www.gitignore.io/api/python,intellij+all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- 'unresolved-import' message (covered by pylint 'import-error' already)
+
+### Fix
+- Detection of first vs third-party modules (now supports VCS deps)
 
 ## [1.0.1] - 2019-11-05
 ### Fix

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -232,10 +232,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:0961bf3429691b9cd7e3695a37ee8bc18e95c56ac1271dc2bbc41697062d1b6d",
+                "sha256:8997c62f779045b07273e124bbe1d03e2eebb9a38a7ef0798fea4bae72b4b6a3"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.3"
         },
         "pytest": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "astroid",
         "importlib-metadata",
         "setuptools",
+        "isort",
     ],
     tests_require=[
         "pytest"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -104,25 +104,3 @@ def test_missing_requirement_importfrom(code, expected_msg_args):
     )
     with expect_messages([expected_msg]) as checker:
         checker.visit_importfrom(importfrom_node)
-
-
-def test_unresolved_import():
-    import_node = astroid.extract_node('import none_existing_module')
-    expected_msg = pylint.testutils.Message(
-        msg_id='unresolved-import',
-        args='none_existing_module',
-        node=import_node,
-    )
-    with expect_messages([expected_msg]) as checker:
-        checker.visit_import(import_node)
-
-
-def test_unresolved_importfrom():
-    import_nodefrom = astroid.extract_node('from none_existing_module import func')
-    expected_msg = pylint.testutils.Message(
-        msg_id='unresolved-import',
-        args='none_existing_module',
-        node=import_nodefrom,
-    )
-    with expect_messages([expected_msg]) as checker:
-        checker.visit_importfrom(import_nodefrom)


### PR DESCRIPTION
Improve the filter that tries to weed out stdlib packages.

This is done by taking inspiration from [pylint itself](https://github.com/PyCQA/pylint/blob/ee8bd98579d1387a5e592ad42f87c80e536ad457/pylint/checkers/imports.py#L719)