### PR TITLE
test import of editable installs and namespace imports (bug report)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,8 @@ pylint-import-requirements = {editable = true,path = "."}
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
+pylint-import-requirements-test-simple = {editable = true, path = "./tests/test-packages/simple"}
+pylint-import-requirements-test-namespace = {path = "./tests/test-packages/namespace"}
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ecce70792e3bf4666c84c5bda00db515b5101cfc774b71d584ee4f01e8a44622"
+            "sha256": "f90f76e0c5519b689a065b152a27ce4e98d8c9423d7d1844d84be3e38c58130c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -230,12 +230,19 @@
             ],
             "version": "==1.8.0"
         },
+        "pylint-import-requirements-test-namespace": {
+            "path": "./tests/test-packages/namespace"
+        },
+        "pylint-import-requirements-test-simple": {
+            "editable": true,
+            "path": "./tests/test-packages/simple"
+        },
         "pyparsing": {
             "hashes": [
-                "sha256:0961bf3429691b9cd7e3695a37ee8bc18e95c56ac1271dc2bbc41697062d1b6d",
-                "sha256:8997c62f779045b07273e124bbe1d03e2eebb9a38a7ef0798fea4bae72b4b6a3"
+                "sha256:4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1",
+                "sha256:61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"
             ],
-            "version": "==2.4.3"
+            "version": "==2.4.4"
         },
         "pytest": {
             "hashes": [

--- a/tests/test-packages/namespace/pylint_import_requirements_test_namespace/mod/__init__.py
+++ b/tests/test-packages/namespace/pylint_import_requirements_test_namespace/mod/__init__.py
@@ -1,0 +1,2 @@
+def func():
+    pass

--- a/tests/test-packages/namespace/setup.py
+++ b/tests/test-packages/namespace/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    name='pylint-import-requirements-test-namespace',
+    packages=setuptools.find_namespace_packages(),
+)

--- a/tests/test-packages/simple/pylint_import_requirements_test_simple/__init__.py
+++ b/tests/test-packages/simple/pylint_import_requirements_test_simple/__init__.py
@@ -1,0 +1,2 @@
+def func():
+    pass

--- a/tests/test-packages/simple/setup.py
+++ b/tests/test-packages/simple/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    name='pylint-import-requirements-test-simple',
+    packages=setuptools.find_packages(),
+)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -73,6 +73,13 @@ def test_clean_importfrom(code):
     ('import importlib_metadata', ('importlib_metadata', 'importlib-metadata')),
     ('import setuptools.monkey', ('setuptools.monkey', 'setuptools')),
     ('import setuptools.monkey as simian', ('setuptools.monkey', 'setuptools')),
+    ('import pylint_import_requirements_test_namespace',
+     ('pylint_import_requirements_test_namespace', '')),
+    ('import pylint_import_requirements_test_namespace.mod',
+     ('pylint_import_requirements_test_namespace.mod', 'pylint-import-requirements-test-namespace')),
+    # editable:
+    ('import pylint_import_requirements_test_simple',
+     ('pylint_import_requirements_test_simple', 'pylint-import-requirements-test-simple')),
 ])
 def test_missing_requirement_import(code, expected_msg_args):
     import_node = astroid.extract_node(code)
@@ -94,6 +101,13 @@ def test_missing_requirement_import(code, expected_msg_args):
      ('setuptools', 'setuptools')),
     ('from setuptools.monkey import patch_all as make_great_again',
      ('setuptools.monkey', 'setuptools')),
+    ('from pylint_import_requirements_test_namespace import mod',
+     ('pylint_import_requirements_test_namespace.mod', 'pylint-import-requirements-test-namespace')),
+    ('from pylint_import_requirements_test_namespace.mod import func',
+     ('pylint_import_requirements_test_namespace.mod', 'pylint-import-requirements-test-namespace')),
+    # editable:
+    ('from pylint_import_requirements_test_simple import func',
+     ('pylint_import_requirements_test_simple', 'pylint-import-requirements-test-simple')),
 ])
 def test_missing_requirement_importfrom(code, expected_msg_args):
     importfrom_node = astroid.extract_node(code)


### PR DESCRIPTION
```sh
$ pipenv run python
Python 3.6.8 (default, Oct  7 2019, 12:59:55)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import isort
>>> isort_obj = isort.SortImports(file_contents="")
>>> isort_obj.place_module('not_numpy')
'FIRSTPARTY'
>>> isort_obj.place_module('not_numpy')
'FIRSTPARTY'
>>> import pylint_import_requirements_test_simple
>>> isort_obj.place_module('pylint_import_requirements_test_simple')
'FIRSTPARTY'
>>> isort_obj.place_module('pylint_import_requirements_test_namespace')
'THIRDPARTY'
>>> isort_obj.place_module('pylint_import_requirements_test_namespace.mod')
'THIRDPARTY'
>>> 
```