### PR TITLE
fix: resolve uppercase letter in package name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# https://docs.travis-ci.com/user/
 language: python
 
 python:
@@ -8,6 +9,9 @@ python:
 
 # required for python >= 3.7
 dist: xenial
+
+env:
+- PIPENV_IGNORE_VIRTUALENVS=1
 
 install:
 - pip install pipenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fix
 - Detection of first vs third-party modules (now supports VCS deps)
+- Packages with uppercase letters are detected correctly
 
 ## [1.0.1] - 2019-11-05
 ### Fix

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ pylint-import-requirements = {editable = true,path = "."}
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
+uppercase = {path = "./tests/test-packages/uppercase"}
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ecce70792e3bf4666c84c5bda00db515b5101cfc774b71d584ee4f01e8a44622"
+            "sha256": "c58131c194d67935427db4b04ba2a24006e6954887c39a8f88eb2273b318acbe"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "astroid": {
             "hashes": [
-                "sha256:09a3fba616519311f1af8a461f804b68f0370e100c9264a035aa7846d7852e33",
-                "sha256:5a79c9b4bd6c4be777424593f957c996e20beb5f74e0bc332f47713c6f675efe"
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
-            "version": "==2.3.2"
+            "version": "==2.3.3"
         },
         "importlib-metadata": {
             "hashes": [
@@ -90,10 +90,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12"
+            "version": "==1.13.0"
         },
         "typed-ast": {
             "hashes": [
@@ -232,10 +232,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:0961bf3429691b9cd7e3695a37ee8bc18e95c56ac1271dc2bbc41697062d1b6d",
-                "sha256:8997c62f779045b07273e124bbe1d03e2eebb9a38a7ef0798fea4bae72b4b6a3"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.3"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
@@ -255,10 +255,13 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12"
+            "version": "==1.13.0"
+        },
+        "uppercase": {
+            "path": "./tests/test-packages/uppercase"
         },
         "wcwidth": {
             "hashes": [

--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -62,7 +62,7 @@ class ImportRequirementsLinter(BaseChecker):
         )  # type: Set[Distribution]
 
         allowed_distributions = {
-            get_distribution(x).key for x in run_setup("setup.py").install_requires
+            get_distribution(x).project_name for x in run_setup("setup.py").install_requires
         }
 
         for dist in all_loadable_distributions:

--- a/tests/test-packages/uppercase/setup.py
+++ b/tests/test-packages/uppercase/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    name='UppercaSe',
+    packages=['uppercase'],
+)

--- a/tests/test-packages/uppercase/uppercase/__init__.py
+++ b/tests/test-packages/uppercase/uppercase/__init__.py
@@ -1,0 +1,2 @@
+def bla():
+    pass

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -24,7 +24,7 @@ def expect_messages(expected_messages: typing.List[pylint.testutils.Message]) \
 def mock_package(tmpdir) -> typing.Iterator[None]:
     tmpdir.join('setup.py').write_text(
         "import setuptools\n"
-        "setuptools.setup(install_requires=['astroid', 'pylint'])\n",
+        "setuptools.setup(install_requires=['astroid', 'pylint', 'UppercaSe'])\n",
         encoding='utf-8',
     )
     tmpdir.join('_test_module.py').write_text(
@@ -49,6 +49,7 @@ def mock_package(tmpdir) -> typing.Iterator[None]:
     'import astroid as hypocycloid',
     'import pylint.testutils',
     'import _test_module',
+    'import uppercase',
 ])
 def test_clean_import(code):
     import_node = astroid.extract_node(code)
@@ -61,6 +62,7 @@ def test_clean_import(code):
     'from astroid import extract_node as astroid_extract_node',
     'from pylint.testutils import Message, UnittestLinter',
     'from _test_module import hello',
+    'from uppercase import bla',
 ])
 def test_clean_importfrom(code):
     importfrom_node = astroid.extract_node(code)


### PR DESCRIPTION
Importing `netCDF4` lead to messages even if `netCDF4` is in requirements.
This was because the resolved requirements from the setup used the wrong
accessor to get the "real" package name. The `key` value of a distribution
object seems to cause everything to be converted to lowercase.