### PR TITLE
Add new lint: `unused-requirement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Add
+- New lint: "unused-requirement": catches any requirement that is never
+  imported in code
 
 ## [1.0.3] - 2019-11-11
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Add
 - New lint: "unused-requirement": catches any requirement that is never
   imported in code
+- New lint: "relative-import-across-packages": catches relative imports
+  across namespace packages
 
 ## [1.0.3] - 2019-11-11
 ### Fix

--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -137,7 +137,7 @@ class ImportRequirementsLinter(BaseChecker):
 
     def close(self):
         superfluous_distributions = self.allowed_distributions - self.visited_distributions
-        for name in superfluous_distributions:
+        for name in sorted(superfluous_distributions):
             self.add_message("unused-requirement", line=0, args=(name,))
 
     def check_import(self, node, modname: str, names: Optional[List[str]] = None):

--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -268,11 +268,27 @@ class ImportRequirementsLinter(BaseChecker):
         return import_category in {"FUTURE", "STDLIB"}
 
     def _is_first_party_module(self, module) -> bool:
+        """Check if the given module is from a first party package
+
+        In order to match up module names with package names it may be necessary to strip the
+        trailing segment. Generally, if there is a directory structure like:
+
+        foo:
+            __init__.py
+            bar.py
+        setup.py
+
+        In this case, package names would be ['foo'], while the module in bar.py would be referenced
+        by 'foo.bar'. In this case __init__.py would be named just 'foo'.
+
+        Because of this, there is a 2 stage lookup:
+        1. if the module name matches one of the known first party names, it is a first party module
+        2. split the name at the last '.'. If everything before the last '.' is in the first party
+           names, it is also accepted as first party module
+        """
         if module in self.first_party_packages:
             return True
-        if "." not in module:
-            return False
-        package_name = module.rpartition(".")[0]
+        package_name = module.rpartition(".")[0]  # rpartition always returns 3 items
         return package_name in self.first_party_packages
 
     def process_tokens(self, tokens: List[TokenInfo]):

--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -86,7 +86,7 @@ class ImportRequirementsLinter(BaseChecker):
         )  # type: Set[Distribution]
 
         setup_result = run_setup("setup.py")
-        self.first_party_packages = setup_result.packages
+        self.first_party_packages = setup_result.packages or []
         self.allowed_distributions = {
             get_distribution(x).project_name for x in setup_result.install_requires
         }
@@ -159,10 +159,7 @@ class ImportRequirementsLinter(BaseChecker):
         """
         # Step 1
         if self._is_first_party_module(modname):
-            print(f"    first party: {modname}")
             return
-
-        print(f"Not first party: {modname}")
 
         # Step 2
         if self._is_stdlib_module(modname):

--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -68,7 +68,10 @@ class ImportRequirementsLinter(BaseChecker):
         "W6668": (
             "install_requires: '%s' does not seem to be used",
             "unused-requirement",
-            "all requirements should be used in code at least once",
+            "All requirements should be used in code at least once.\n"
+            "If there are imports that are required because they are lazy loaded as a transitive "
+            "dependency, consider using a control comment:\n"
+            f"```# {_REQUIRES_INSTALL_PREFIX} imports=<distribution-name>```",
             {
                 "scope": "package"
             }
@@ -273,6 +276,15 @@ class ImportRequirementsLinter(BaseChecker):
         return package_name in self.first_party_packages
 
     def process_tokens(self, tokens: List[TokenInfo]):
+        """Scan tokens to respond to control comments.
+
+        An example of a control comment:
+        ```
+        import pandas as pd
+
+        pd.read_feather('file.feather')  # pylint-import-requirements: imports=pyarrow
+        ```
+        """
         for token in tokens:
             if token.type != COMMENT:
                 continue

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -17,16 +17,17 @@ def expect_messages(expected_messages: typing.List[pylint.testutils.Message]) \
     linter = pylint.testutils.UnittestLinter()
     yield ImportRequirementsLinter(linter)
     issued_messages = linter.release_messages()
-    assert len(expected_messages) == len(issued_messages)
-    for m in issued_messages:
-        assert any((e == m for e in expected_messages))
+    assert issued_messages == expected_messages
 
 
 @pytest.fixture(autouse=True)
 def mock_package(tmpdir) -> typing.Iterator[None]:
     tmpdir.join('setup.py').write_text(
         "import setuptools\n"
-        "setuptools.setup(install_requires=['astroid', 'pylint', 'UppercaSe'])\n",
+        "setuptools.setup(\n"
+        "   packages=['_test_module'],\n"
+        "   install_requires=['astroid', 'pylint', 'UppercaSe'],\n"
+        ")\n",
         encoding='utf-8',
     )
     tmpdir.join('_test_module.py').write_text(

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -143,8 +143,8 @@ def test_missing_requirement_importfrom(code, expected_msg_args):
                 'import pylint.testutils',
                 'import _test_module',
             ], [
-                ('astroid',),
                 ('UppercaSe',),
+                ('astroid',),
             ]
     ),
 ])

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -17,7 +17,9 @@ def expect_messages(expected_messages: typing.List[pylint.testutils.Message]) \
     linter = pylint.testutils.UnittestLinter()
     yield ImportRequirementsLinter(linter)
     issued_messages = linter.release_messages()
-    assert expected_messages == issued_messages
+    assert len(expected_messages) == len(issued_messages)
+    for m in issued_messages:
+        assert any((e == m for e in expected_messages))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Add a new lint `unused-requirement`. This lint catches any requirement specified that is not directly imported.