### PR TITLE
namespaces: do not mark namespace packages as first party

### DIFF
--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -42,6 +42,16 @@ def _is_namespace_spec(spec) -> bool:
     return spec.origin is None
 
 
+def _filter_non_namespace_packages(package_names: List[str]) -> List[str]:
+    """Given a list of packages, only return those names that are NOT a namespace package"""
+    result = []
+    for name in package_names:
+        spec = importlib.util.find_spec(name)
+        if spec and not _is_namespace_spec(spec):
+            result.append(name)
+    return result
+
+
 class ImportRequirementsLinter(BaseChecker):
     """Check that all import statements are covered by `install_requires` statements"""
 
@@ -98,7 +108,7 @@ class ImportRequirementsLinter(BaseChecker):
         )  # type: Set[Distribution]
 
         setup_result = run_setup("setup.py")
-        self.first_party_packages = setup_result.packages or []
+        self.first_party_packages = _filter_non_namespace_packages(setup_result.packages or [])
         self.allowed_distributions = {
             get_distribution(x).project_name for x in setup_result.install_requires
         }

--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -47,8 +47,15 @@ def _filter_non_namespace_packages(package_names: List[str]) -> List[str]:
     result = []
     for name in package_names:
         spec = importlib.util.find_spec(name)
-        if spec and not _is_namespace_spec(spec):
-            result.append(name)
+        if not spec:
+            # Could not load module, so its probably not a package
+            continue
+        if _is_namespace_spec(spec) and len(spec.submodule_search_locations) >= 2:
+            # Its a namespace package with more than 2 search locations
+            continue
+        # The package is directly importable, or a namespace package with only 1
+        # search locations, i.e. not really a namespace at all
+        result.append(name)
     return result
 
 

--- a/tests/test-packages/namespace/setup.py
+++ b/tests/test-packages/namespace/setup.py
@@ -2,5 +2,5 @@ import setuptools
 
 setuptools.setup(
     name='namespace',
-    packages=['name.space'],
+    packages=['name', 'name.space'],
 )

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -21,8 +21,8 @@ def expect_messages(expected_messages: typing.List[pylint.testutils.Message]) \
     assert issued_messages == expected_messages
 
 
-@pytest.fixture(autouse=True)
-def mock_package(tmpdir) -> typing.Iterator[None]:
+@pytest.fixture()
+def mock_only_uppercase(tmpdir) -> typing.Iterator[None]:
     tmpdir.join('setup.py').write_text(
         "import setuptools\n"
         "setuptools.setup(\n"
@@ -47,6 +47,34 @@ def mock_package(tmpdir) -> typing.Iterator[None]:
         sys.path = old_path
 
 
+@pytest.fixture()
+def mock_only_namespace(tmpdir) -> typing.Iterator[None]:
+    tmpdir.join('setup.py').write_text(
+        "import setuptools\n"
+        "setuptools.setup(\n"
+        "   packages=['name', 'name.foo'],\n"
+        "   install_requires=['astroid', 'pylint', 'namespace'],\n"
+        ")\n",
+        encoding='utf-8',
+    )
+    namespace_dir = tmpdir.join("name", "foo")
+    namespace_dir.ensure(dir=True)
+    namespace_dir.join('__init__.py').write_text(
+        "def hello():\n"
+        "   pass\n",
+        encoding='utf-8',
+    )
+    old_cwd = os.getcwd()
+    os.chdir(tmpdir.strpath)
+    old_path = copy.copy(sys.path)
+    sys.path.insert(0, tmpdir.strpath)
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)
+        sys.path = old_path
+
+
 @pytest.mark.parametrize('code', [
     'import astroid',
     'import pylint',
@@ -55,7 +83,20 @@ def mock_package(tmpdir) -> typing.Iterator[None]:
     'import _test_module',
     'import uppercase',
 ])
-def test_clean_import(code):
+def test_clean_import(mock_only_uppercase, code):
+    import_node = astroid.extract_node(code)
+    with expect_messages([]) as checker:
+        checker.visit_import(import_node)
+
+
+@pytest.mark.parametrize('code', [
+    'import astroid',
+    'import pylint',
+    'import astroid as hypocycloid',
+    'import pylint.testutils',
+    'import name.foo',
+])
+def test_clean_import_ns(mock_only_namespace, code):
     import_node = astroid.extract_node(code)
     with expect_messages([]) as checker:
         checker.visit_import(import_node)
@@ -68,7 +109,20 @@ def test_clean_import(code):
     'from _test_module import hello',
     'from uppercase import bla',
 ])
-def test_clean_importfrom(code):
+def test_clean_importfrom(mock_only_uppercase, code):
+    importfrom_node = astroid.extract_node(code)
+    with expect_messages([]) as checker:
+        checker.visit_importfrom(importfrom_node)
+
+
+@pytest.mark.parametrize('code', [
+    'from astroid import extract_node',
+    'from astroid import extract_node as astroid_extract_node',
+    'from pylint.testutils import Message, UnittestLinter',
+    'from _test_module import hello',
+    'from name import foo',
+])
+def test_clean_importfrom_ns(mock_only_namespace, code):
     importfrom_node = astroid.extract_node(code)
     with expect_messages([]) as checker:
         checker.visit_importfrom(importfrom_node)
@@ -82,7 +136,27 @@ def test_clean_importfrom(code):
     ('import name', ('name', 'namespace')),
     ('import name.space', ('name.space', 'namespace')),
 ])
-def test_missing_requirement_import(code, expected_msg_args):
+def test_missing_requirement_import(mock_only_uppercase, code,
+                                    expected_msg_args):
+    import_node = astroid.extract_node(code)
+    expected_msg = pylint.testutils.Message(
+        msg_id='missing-requirement',
+        args=expected_msg_args,
+        node=import_node,
+    )
+    with expect_messages([expected_msg]) as checker:
+        checker.visit_import(import_node)
+
+
+@pytest.mark.parametrize(('code', 'expected_msg_args'), [
+    ('import setuptools', ('setuptools', 'setuptools')),
+    ('import importlib_metadata', ('importlib_metadata', 'importlib-metadata')),
+    ('import setuptools.monkey', ('setuptools.monkey', 'setuptools')),
+    ('import setuptools.monkey as simian', ('setuptools.monkey', 'setuptools')),
+    ('import uppercase', ('uppercase', 'UppercaSe')),
+])
+def test_missing_requirement_import_ns(mock_only_namespace, code,
+                                       expected_msg_args):
     import_node = astroid.extract_node(code)
     expected_msg = pylint.testutils.Message(
         msg_id='missing-requirement',
@@ -105,7 +179,31 @@ def test_missing_requirement_import(code, expected_msg_args):
     ('from name import space', ('name.space', 'namespace')),
     ('from name.space import hello_world', ('name.space', 'namespace')),
 ])
-def test_missing_requirement_importfrom(code, expected_msg_args):
+def test_missing_requirement_importfrom(mock_only_uppercase, code,
+                                        expected_msg_args):
+    importfrom_node = astroid.extract_node(code)
+    expected_msg = pylint.testutils.Message(
+        msg_id='missing-requirement',
+        args=expected_msg_args,
+        node=importfrom_node,
+    )
+    with expect_messages([expected_msg]) as checker:
+        checker.visit_importfrom(importfrom_node)
+
+
+@pytest.mark.parametrize(('code', 'expected_msg_args'), [
+    ('from importlib_metadata import Distribution',
+     ('importlib_metadata', 'importlib-metadata')),
+    ('from importlib_metadata import *',
+     ('importlib_metadata', 'importlib-metadata')),
+    ('from setuptools import monkey as simian',
+     ('setuptools', 'setuptools')),
+    ('from setuptools.monkey import patch_all as make_great_again',
+     ('setuptools.monkey', 'setuptools')),
+    ('from uppercase import bla', ('uppercase', 'UppercaSe')),
+])
+def test_missing_requirement_importfrom_ns(mock_only_namespace, code,
+                                           expected_msg_args):
     importfrom_node = astroid.extract_node(code)
     expected_msg = pylint.testutils.Message(
         msg_id='missing-requirement',
@@ -149,7 +247,8 @@ def test_missing_requirement_importfrom(code, expected_msg_args):
             ]
     ),
 ])
-def test_unused_requirements(codelines, expected_msgs_args):
+def test_unused_requirements(mock_only_uppercase, codelines,
+                             expected_msgs_args):
     expected_msgs = []
     for msg_args in expected_msgs_args:
         expected_msgs.append(pylint.testutils.Message(
@@ -201,7 +300,7 @@ def test_unused_requirements(codelines, expected_msgs_args):
             ]
     ),
 ])
-def test_comment_control(comments, expected_msgs_args):
+def test_comment_control(mock_only_uppercase, comments, expected_msgs_args):
     expected_msgs = []
     for msg_args in expected_msgs_args:
         expected_msgs.append(pylint.testutils.Message(
@@ -212,6 +311,78 @@ def test_comment_control(comments, expected_msgs_args):
     with expect_messages(expected_msgs) as checker:
         checker.open()
         checker.process_tokens(tokenize.tokenize(iter(comments).__next__))
+        checker.close()
+
+
+@pytest.mark.parametrize(('codelines', 'expected_msgs_args'), [
+    (
+            [
+                'import astroid',
+                'import pylint',
+                'import astroid as hypocycloid',
+                'import pylint.testutils',
+                'import name.space',
+            ], [],
+    ),
+    (
+            [
+                'import astroid',
+                'import pylint',
+                'import astroid as hypocycloid',
+                'import pylint.testutils',
+                'from name import space',
+            ], [],
+    ),
+    (
+            [
+                'import astroid',
+                'import pylint',
+                'import astroid as hypocycloid',
+                'import pylint.testutils',
+                'import name.foo',
+            ], [
+                ('namespace',),
+            ]
+    ),
+    (
+            [
+                'import astroid',
+                'import pylint',
+                'import astroid as hypocycloid',
+                'import pylint.testutils',
+                'from name import foo',
+            ], [
+                ('namespace',),
+            ]
+    ),
+    (
+            [
+                'import pylint',
+                'import pylint.testutils',
+                'from name import foo',
+            ], [
+                ('astroid',),
+                ('namespace',),
+            ]
+    ),
+])
+def test_unused_requirements_ns(mock_only_namespace, codelines,
+                                expected_msgs_args):
+    expected_msgs = []
+    for msg_args in expected_msgs_args:
+        expected_msgs.append(pylint.testutils.Message(
+            msg_id='unused-requirement',
+            args=msg_args,
+            line=0,
+        ))
+    with expect_messages(expected_msgs) as checker:
+        checker.open()
+        for line in codelines:
+            node = astroid.extract_node(line)
+            if isinstance(node, astroid.Import):
+                checker.visit_import(node)
+            else:
+                checker.visit_importfrom(node)
         checker.close()
 
 
@@ -300,7 +471,7 @@ def test_comment_control(comments, expected_msgs_args):
             ],
     ),
 ])
-def test_comment_control_parsing(comments, expected_msgs):
+def test_comment_control_parsing(mock_only_uppercase, comments, expected_msgs):
     with expect_messages(expected_msgs) as checker:
         checker.open()
         checker.process_tokens(tokenize.tokenize(iter(comments).__next__))


### PR DESCRIPTION
namespace packages are no longer added to first party names.
This means that packages in the same namespace should no longer
be detected as first party. This means they should be marked as
a "used" requirement again.

This fixes #13