### PR TITLE
None check on spec loader for step 4. (The bug was introduced in version 2.0.3)

### DIFF
--- a/pylint_import_requirements/__init__.py
+++ b/pylint_import_requirements/__init__.py
@@ -231,9 +231,14 @@ class ImportRequirementsLinter(BaseChecker):
             return
 
         # Step 4
-        if spec.origin is None and (
-            spec.loader.__module__ != "_frozen_importlib_external"
-            or type(spec.loader).__name__ not in ("SourceFileLoader", "_NamespaceLoader")
+        if (
+            spec.origin is None
+            and spec.loader is not None
+            and (
+                spec.loader.__module__ != "_frozen_importlib_external"
+                or type(spec.loader).__name__
+                not in ("SourceFileLoader", "_NamespaceLoader")
+            )
         ):
             return
 


### PR DESCRIPTION
None check on spec loader for step 4. (The bug was introduced in version 2.0.3)

```python
Traceback (most recent call last):
  File "$VIRTUALENV/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/__init__.py", line 22, in run_pylint
    PylintRun(sys.argv[1:])
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/lint/run.py", line 349, in __init__
    linter.check(args)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 862, in check
    self._check_files(
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 896, in _check_files
    self._check_file(get_ast, check_astroid_module, name, filepath, modname)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 922, in _check_file
    check_astroid_module(ast_node)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 1054, in check_astroid_module
    retval = self._check_astroid_module(
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 1099, in _check_astroid_module
    walker.walk(ast_node)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint_import_requirements/__init__.py", line 192, in visit_importfrom
    self.check_import(node, modname, names)
  File "$VIRTUALENV/lib/python3.8/site-packages/pylint_import_requirements/__init__.py", line 235, in check_import
    spec.loader.__module__ != "_frozen_importlib_external"
AttributeError: 'NoneType' object has no attribute '__module__'
```