### PR TITLE
pipeline: make isort update command reproducible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ install:
 - if [ "$TRAVIS_PYTHON_VERSION" = "3.4" ]; then mv Pipfile.lock-python3.4 Pipfile.lock; fi
 - export PIPENV_IGNORE_VIRTUALENVS=1
 - pipenv install --python "$TRAVIS_PYTHON_VERSION" --deploy --dev
+# `pipenv install --select-upgrade [package]` also upgrades dependencies (not reproducible)
 - if [ ! -z "$ISORT_VERSION" ]; then
-    pipenv install --selective-upgrade "isort==$ISORT_VERSION";
+    pipenv run pip install "isort==$ISORT_VERSION";
   fi
 - pipenv graph
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,15 @@ dist: xenial
 
 env:
 - ISORT_VERSION=
-- ISORT_VERSION=5.4.2
+# locked pylint v2.4.4 does not support isort>=v5
+- &isort_v5_env ISORT_VERSION=5.4.2 PYLINT_VERSION=2.6.0
 
 matrix:
   exclude:
   - python: 3.4
-    env: ISORT_VERSION=5.4.2
+    env: *isort_v5_env
   - python: 3.5
-    env: ISORT_VERSION=5.4.2
+    env: *isort_v5_env
 
 install:
 # pipenv v2020.4.1a2 / v2020.5.28 removed support for python3.4 (in vendored pkg_resources)
@@ -31,7 +32,7 @@ install:
 - pipenv install --python "$TRAVIS_PYTHON_VERSION" --deploy --dev
 # `pipenv install --select-upgrade [package]` also upgrades dependencies (not reproducible)
 - if [ ! -z "$ISORT_VERSION" ]; then
-    pipenv run pip install "isort==$ISORT_VERSION";
+    pipenv run pip install "isort==$ISORT_VERSION" "pylint==$PYLINT_VERSION";
   fi
 - pipenv graph
 


### PR DESCRIPTION
no longer update dependencies of isort to their latest version

previously dependencies of isort like `importlib-metadata` were upraded to their latest version.
this behaviour made our pipeline irreproducible.
a new `importlib-metadata` release broke the pipeline on our master